### PR TITLE
fixes triangles on left panel div

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -45,6 +45,9 @@
           <li>Link 2</li>
           <li>Link 3</li>
         </ul>
+        <!-- two grey triangles positioned absolutely relative to left_panel div -->
+        <div class="arrow-down t1"></div>
+        <div class="arrow-down t2"></div>
       </div> <!-- closes left_panel div -->
 
       <div class='right_panel'>


### PR DESCRIPTION
to create the triangles, use two blank divs. reduce their size to 0 width and 0 height. each border intersects another at an angle, thus setting the width and height to 0 makes all borders touch. then set three borders to transparent, set the other border to a color. this will form the triangle.
to position it on the left panel of this div, set the left_panel div to position: relative. then set the triangle divs to position: absolute. also assigned custom classes to both triangle divs in order to target them for positioning. 
added a media query to remove the triangles on smaller screens. this may need to be adjusted; some wider screens/monitors may show the triangle at different resolutions. but for now, this is an improvement in both functionality and code. 